### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# .git-blame-ignore-revs
+# Pre-commit fixes for AdvSND C++
+d57b0cb0cd591340839a6963549169a3e82740e1
+# Pre-commit fixes for AdvSND_geom_config.py
+dc777980daec3e66217c1021a4893726c0510c05
+# Fix missing include of ROOT types
+db396d44c2ef6f81983ae41384228cc97c01c611
+# Clang format
+48f830fe8144e7adfb4ff745bca971a987e6db21
+# AdvTarget: Clang format
+b0b290b83817e959f54ad55325d0397034acd74c


### PR DESCRIPTION
This allows us to still use git blame effectively in presence of commits that do a lot of automatic formatting (see the [Github docs](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view), but this can also be used locally using various tools)