### PR TITLE
Latest geometry update as of September 2024

### DIFF
--- a/geometry/AdvSND_geom_config.py
+++ b/geometry/AdvSND_geom_config.py
@@ -655,7 +655,7 @@ with ConfigRegistry.register_config("basic") as c:
 
     # AdvSND Target & Tracker structure
     c.AdvTarget = AttrDict(z=0 * u.cm)
-    c.AdvTarget.TargetWallX = 45 * u.cm
+    c.AdvTarget.TargetWallX = 40 * u.cm
     c.AdvTarget.TargetWallY = c.AdvTarget.TargetWallX
     c.AdvTarget.TargetWallZ = 7 * u.mm
     c.AdvTarget.AluFrameX = 60 * u.cm
@@ -663,7 +663,7 @@ with ConfigRegistry.register_config("basic") as c:
     c.AdvTarget.AluFrameZ = 7 * u.mm
 
     # Target Tracking stations
-    c.AdvTarget.TTX = 45 * u.cm
+    c.AdvTarget.TTX = 40 * u.cm
     c.AdvTarget.TTY = c.AdvTarget.TTX
     c.AdvTarget.TTZ = 4 * u.mm
     c.AdvTarget.nTT = 58
@@ -683,16 +683,16 @@ with ConfigRegistry.register_config("basic") as c:
 
     # AdvSND MuFilter Layout 2 (SQUARED)
     c.AdvMuFilter = AttrDict(z=0 * u.cm)
-    c.AdvMuFilter.MuonSysPlaneX = 45 * u.cm
+    c.AdvMuFilter.MuonSysPlaneX = 40 * u.cm
     c.AdvMuFilter.MuonSysPlaneY = c.AdvMuFilter.MuonSysPlaneX
     c.AdvMuFilter.MuonSysPlaneZ = 4 * u.mm
-    c.AdvMuFilter.FeX = 105 * u.cm
+    c.AdvMuFilter.FeX = 115.1 * u.cm
     c.AdvMuFilter.FeY = 80.0 * u.cm
     c.AdvMuFilter.FeZ = 5 * u.cm
-    c.AdvMuFilter.FeGap = 7.5 * u.cm
+    c.AdvMuFilter.FeGap = 15.5 * u.cm
     c.AdvMuFilter.Nplanes = 34
-    c.AdvMuFilter.CoilX = 41 * u.cm
+    c.AdvMuFilter.CoilX = 40 * u.cm
     c.AdvMuFilter.CoilY = c.AdvMuFilter.MuonSysPlaneY
-    c.AdvMuFilter.CoilZ = 5 * u.cm
+    c.AdvMuFilter.CoilZ = 5.5 * u.cm
     c.AdvMuFilter.Field = 1.75 * u.tesla
-    c.AdvMuFilter.CurvRadius = 4.5 * u.cm
+    c.AdvMuFilter.CurvRadius = 6.5 * u.cm

--- a/geometry/AdvSND_geom_config.py
+++ b/geometry/AdvSND_geom_config.py
@@ -655,15 +655,19 @@ with ConfigRegistry.register_config("basic") as c:
 
     # AdvSND Target & Tracker structure
     c.AdvTarget = AttrDict(z=0 * u.cm)
-    c.AdvTarget.TargetWallX = 50.0 * u.cm
-    c.AdvTarget.TargetWallY = 50.0 * u.cm
+    c.AdvTarget.TargetWallX = 45 * u.cm
+    c.AdvTarget.TargetWallY = c.AdvTarget.TargetWallX
     c.AdvTarget.TargetWallZ = 7 * u.mm
+    c.AdvTarget.AluFrameX = 60 * u.cm
+    c.AdvTarget.AluFrameY = 60 * u.cm
+    c.AdvTarget.AluFrameZ = 7 * u.mm
 
     # Target Tracking stations
-    c.AdvTarget.TTX = 49.29 * u.cm
-    c.AdvTarget.TTY = 49.29 * u.cm
-    c.AdvTarget.TTZ = 8 * u.mm
-    c.AdvTarget.nTT = 100
+    c.AdvTarget.TTX = 45 * u.cm
+    c.AdvTarget.TTY = c.AdvTarget.TTX
+    c.AdvTarget.TTZ = 4 * u.mm
+    c.AdvTarget.nTT = 58
+    
 
     # AdvSND MuFilter structure
     """
@@ -679,55 +683,16 @@ with ConfigRegistry.register_config("basic") as c:
 
     # AdvSND MuFilter Layout 2 (SQUARED)
     c.AdvMuFilter = AttrDict(z=0 * u.cm)
-    c.AdvMuFilter.MuonSysPlaneX = 60.0 * u.cm
+    c.AdvMuFilter.MuonSysPlaneX = 45 * u.cm
     c.AdvMuFilter.MuonSysPlaneY = c.AdvMuFilter.MuonSysPlaneX
-    c.AdvMuFilter.CutOffset = 3.0 * u.cm
-    # c.AdvMuFilter.FeX               = 160.0 * u.cm
-    # c.AdvMuFilter.FeY               = 166.0 * u.cm #= c.AdvMuFilter.FeX
-    c.AdvMuFilter.FeZ = 8.0 * u.cm
-    c.AdvMuFilter.FeGap = 2.0 * u.cm
-    c.AdvMuFilter.Nplanes = 22
-    c.AdvMuFilter.CoilX = c.AdvMuFilter.MuonSysPlaneX
-    c.AdvMuFilter.CoilY = 9.2 * u.cm
-    c.AdvMuFilter.FeX = 2 * c.AdvMuFilter.MuonSysPlaneX
-    c.AdvMuFilter.FeY = 2 * c.AdvMuFilter.MuonSysPlaneY + 3 * c.AdvMuFilter.CoilY
+    c.AdvMuFilter.MuonSysPlaneZ = 4 * u.mm
+    c.AdvMuFilter.FeX = 105 * u.cm
+    c.AdvMuFilter.FeY = 80.0 * u.cm
+    c.AdvMuFilter.FeZ = 5 * u.cm
+    c.AdvMuFilter.FeGap = 7.5 * u.cm
+    c.AdvMuFilter.Nplanes = 34
+    c.AdvMuFilter.CoilX = 41 * u.cm
+    c.AdvMuFilter.CoilY = c.AdvMuFilter.MuonSysPlaneY
+    c.AdvMuFilter.CoilZ = 5 * u.cm
     c.AdvMuFilter.Field = 1.75 * u.tesla
-    c.AdvMuFilter.NBars = 20
-    c.AdvMuFilter.BarGap = 0.1 * u.mm
-    # AdvSND Downstream magnet
-    c.AdvMuFilter.DownCutOffset = 30.0 * u.cm
-    c.AdvMuFilter.DownFeZ = 160.0 * u.cm
-    c.AdvMuFilter.CoilThickY = 9.2 * u.cm
-    (
-        c.AdvMuFilter.MagTracker1X,
-        c.AdvMuFilter.MagTracker2X,
-        c.AdvMuFilter.MagTracker3X,
-    ) = 60 * u.cm, 70 * u.cm, 90 * u.cm
-    (
-        c.AdvMuFilter.MagTracker1Y,
-        c.AdvMuFilter.MagTracker2Y,
-        c.AdvMuFilter.MagTracker3Y,
-    ) = (
-        c.AdvMuFilter.MagTracker1X,
-        c.AdvMuFilter.MagTracker2X,
-        c.AdvMuFilter.MagTracker3X,
-    )
-    c.AdvMuFilter.MagTrackerZ = 25 * u.mm
-    # c.AdvMuFilter.DownFeX           = 200. * u.cm
-    # c.AdvMuFilter.DownFeY           = 228. * u.cm
-    c.AdvMuFilter.DownFeX = (200.0 / 120.0) * c.AdvMuFilter.MagTracker3X
-    c.AdvMuFilter.DownFeY = (228.0 / 120.0) * c.AdvMuFilter.MagTracker3Y
-    c.AdvMuFilter.DownFeYokeX = (
-        c.AdvMuFilter.DownFeX - c.AdvMuFilter.MagTracker2X
-    ) / 2.0
-    c.AdvMuFilter.DownFeYokeY = (
-        c.AdvMuFilter.DownFeY - c.AdvMuFilter.MagTracker2Y - c.AdvMuFilter.CoilThickY
-    ) / 2.0
-    c.AdvMuFilter.DownFeCutX = c.AdvMuFilter.DownFeYokeX - c.AdvMuFilter.DownCutOffset
-    c.AdvMuFilter.DownFeCutY = c.AdvMuFilter.DownFeYokeY - c.AdvMuFilter.DownCutOffset
-    c.AdvMuFilter.IronCoreZ = c.AdvMuFilter.DownFeZ
-    c.AdvMuFilter.IronCoreX1 = c.AdvMuFilter.MagTracker2X
-    c.AdvMuFilter.IronCoreX2 = c.AdvMuFilter.MagTracker3X
-    c.AdvMuFilter.IronCoreY1 = c.AdvMuFilter.IronCoreX1
-    c.AdvMuFilter.IronCoreY2 = c.AdvMuFilter.IronCoreX2
-    c.AdvMuFilter.DownField = 1.75 * u.tesla
+    c.AdvMuFilter.CurvRadius = 4.5 * u.cm

--- a/shipLHC/AdvMuFilter.cxx
+++ b/shipLHC/AdvMuFilter.cxx
@@ -160,6 +160,9 @@ void AdvMuFilter::ConstructGeometry()
     Double_t fFeYokeX = (fFeX-fMuonSysPlaneX-2*fFeGap)/2.;
     Double_t fFeYokeY = (fFeY-fMuonSysPlaneY)/2.;
 
+    LOG(INFO) << " CoilX: " << fCoilX << " cm" << endl;
+    LOG(INFO) << " FeYokeX: " << fFeYokeX << " cm" << endl;
+    LOG(INFO) << " FeYokeY: " << fFeYokeY << " cm" << endl;
 
     TGeoVolumeAssembly *volAdvMuFilter = new TGeoVolumeAssembly("volAdvMuFilter");
 
@@ -177,7 +180,7 @@ void AdvMuFilter::ConstructGeometry()
                       new TGeoTranslation(-2.4244059999999976 - EmWall0_survey.X(),
                                           38.3,
                                           354.862 + 3 + 1 + fFeZ / 2. - 41.895793 + 1. - 3.854227000000008
-                                              + 3.7497190000000046 - 64.414875));   // hardcoded, try to find and elegant solution
+                                              + 3.7497190000000046 - 64.44596200000001));   // hardcoded, try to find and elegant solution
     
     // Iron and Detector's shapes
     TGeoBBox *FeBlock = new TGeoBBox("FeBlock", fFeX/2., fFeY/2., fFeZ/2.);

--- a/shipLHC/Floor.cxx
+++ b/shipLHC/Floor.cxx
@@ -194,8 +194,8 @@ void Floor::ConstructGeometry()
          Double_t CurrentTargetY = 9.564471+5.368296; // current y coordinate of the target low edge, hardcoded due to time constraints, find better way
 
          Double_t ShiftX = TargetX/2.+0.0033519999999995775+2.;
-         Double_t ShiftY = -CurrentTargetY-20.188581+4;
-         Double_t ShiftZ = -400.;
+         Double_t ShiftY = -CurrentTargetY-20.188581+4+9.078588;
+         Double_t ShiftZ = -200;
          ////////////////////////////////////////////
          auto localSND_physCS_comb = new TGeoCombiTrans("localSND_physCS",0.+ShiftX,0.+ShiftY, 0.+ShiftZ,localSND_physCS_rot);    // origin is 480m downstream of IP1, shifting the apparatus 4m upstream
          localSND_physCS_comb->RegisterYourself();

--- a/shipLHC/Floor.cxx
+++ b/shipLHC/Floor.cxx
@@ -368,9 +368,10 @@ void Floor::ConstructGeometry()
   LOG(DEBUG) << "shapes "<<shapes[0]->GetName()<<" "<<shapes[1]->GetName()<<" "<<shapes[2]->GetName();
   /**** Hand changes to fit the AdvSND apparatus ****/ 
   //TVector3 detdim(89.998020, 107.989308, 362.541092+2.);
-  TVector3 detdim(99.997800+6, 113.988714+25, 281.160616+2.+70); // new 2024
+  //TVector3 detdim(99.997800+6, 113.988714+25, 281.160616+2.+50); // new 2024
+  TVector3 detdim(60, 100, 200); // new Aug 2024
   //auto Detpos = new TGeoTranslation("Detpos", -0.2024000+ShiftX, 30.581334+ShiftY, 620.85947+ShiftZ);
-  auto Detpos = new TGeoTranslation("Detpos", ShiftX-99.997800/2+22., ShiftY+113.988714/2.-10, ShiftZ+2*279.160616-22.-30); // new 2024
+  auto Detpos = new TGeoTranslation("Detpos", ShiftX-99.997800/2+22., ShiftY+113.988714/2.-10, ShiftZ+2*279.160616-22.-250); // new 2024
   Detpos->RegisterYourself();
   auto DetShape = new TGeoBBox("DetShape", detdim.X(), detdim.Y(), detdim.Z());
   /////////////////////////////////////////////

--- a/shipLHC/scripts/2dEventDisplay.py
+++ b/shipLHC/scripts/2dEventDisplay.py
@@ -36,7 +36,7 @@ parser.add_argument("-P", "--partition", dest="partition", help="partition of da
 parser.add_argument("--server", dest="server", help="xrootd server",default=os.environ["EOSSHIP"])
 parser.add_argument("-X", dest="extraInfo", help="print extra event info",default=True)
 
-parser.add_argument("-par", "--parFile", dest="parFile", help="parameter file", default=os.environ['SNDSW_ROOT']+"/python/TrackingParams.xml")
+parser.add_argument("-par", "--parFile", dest="parFile", help="parameter file", default=os.environ['ADVSNDSW_ROOT']+"/python/TrackingParams.xml")
 parser.add_argument("-hf", "--HoughSpaceFormat", dest="HspaceFormat", help="Hough space representation. Should match the 'Hough_space_format' name in parFile, use quotes", default='linearSlopeIntercept')
 
 options = parser.parse_args()


### PR DESCRIPTION
This version includes the recent changes that have been made to the AdvSND geometry, i.e. :

- Change of orientation of the coil, magnetic field is now **vertical**
- Dimensions of the HCAL and the target are compliant to the design proposed by the [magnet group](https://indico.cern.ch/event/1452210/contributions/6144500/attachments/2934536/5154025/240925_Quercia_AdvSND_magnet.pdf) and by [L. Krzempek](https://indico.cern.ch/event/1452210/contributions/6134184/attachments/2934459/5153816/SND%20COLLABORATION%20MEETING%2025%20SEPT%20-%202024.pdf) and included in the [Addendum to the LOI](https://cds.cern.ch/record/2909524/files/LHCC-I-040-ADD-1.pdf).

Caveats: 
- no modelling of the silicon modules is implemented, detectors are implemented as just sensitive volumes.
- Target and HCAL have the same configuration in terms of detector planes, every detector plane is 4mm thick and between two tungsten (or iron) planes there are two detector ones (with different detectorID!)