### PR TITLE
Run4 no exc opt overlap modules

### DIFF
--- a/geometry/AdvSND_geom_config.py
+++ b/geometry/AdvSND_geom_config.py
@@ -655,7 +655,7 @@ with ConfigRegistry.register_config("basic") as c:
 
     # AdvSND Target & Tracker structure
     c.AdvTarget = AttrDict(z=0 * u.cm)
-    c.AdvTarget.TargetWallX = 45 * u.cm
+    c.AdvTarget.TargetWallX = 40 * u.cm
     c.AdvTarget.TargetWallY = c.AdvTarget.TargetWallX
     c.AdvTarget.TargetWallZ = 7 * u.mm
     c.AdvTarget.AluFrameX = 60 * u.cm
@@ -663,7 +663,7 @@ with ConfigRegistry.register_config("basic") as c:
     c.AdvTarget.AluFrameZ = 7 * u.mm
 
     # Target Tracking stations
-    c.AdvTarget.TTX = 45 * u.cm
+    c.AdvTarget.TTX = 40 * u.cm
     c.AdvTarget.TTY = c.AdvTarget.TTX
     c.AdvTarget.TTZ = 4 * u.mm
     c.AdvTarget.nTT = 58
@@ -683,16 +683,16 @@ with ConfigRegistry.register_config("basic") as c:
 
     # AdvSND MuFilter Layout 2 (SQUARED)
     c.AdvMuFilter = AttrDict(z=0 * u.cm)
-    c.AdvMuFilter.MuonSysPlaneX = 45 * u.cm
+    c.AdvMuFilter.MuonSysPlaneX = 40 * u.cm
     c.AdvMuFilter.MuonSysPlaneY = c.AdvMuFilter.MuonSysPlaneX
     c.AdvMuFilter.MuonSysPlaneZ = 4 * u.mm
-    c.AdvMuFilter.FeX = 105 * u.cm
+    c.AdvMuFilter.FeX = 115.1 * u.cm
     c.AdvMuFilter.FeY = 80.0 * u.cm
     c.AdvMuFilter.FeZ = 5 * u.cm
-    c.AdvMuFilter.FeGap = 7.5 * u.cm
+    c.AdvMuFilter.FeGap = 15.5 * u.cm
     c.AdvMuFilter.Nplanes = 34
-    c.AdvMuFilter.CoilX = 41 * u.cm
+    c.AdvMuFilter.CoilX = 40 * u.cm
     c.AdvMuFilter.CoilY = c.AdvMuFilter.MuonSysPlaneY
-    c.AdvMuFilter.CoilZ = 5 * u.cm
+    c.AdvMuFilter.CoilZ = 5.5 * u.cm
     c.AdvMuFilter.Field = 1.75 * u.tesla
-    c.AdvMuFilter.CurvRadius = 4.5 * u.cm
+    c.AdvMuFilter.CurvRadius = 6.5 * u.cm

--- a/geometry/AdvSND_geom_config.py
+++ b/geometry/AdvSND_geom_config.py
@@ -655,15 +655,19 @@ with ConfigRegistry.register_config("basic") as c:
 
     # AdvSND Target & Tracker structure
     c.AdvTarget = AttrDict(z=0 * u.cm)
-    c.AdvTarget.TargetWallX = 50.0 * u.cm
-    c.AdvTarget.TargetWallY = 50.0 * u.cm
+    c.AdvTarget.TargetWallX = 45 * u.cm
+    c.AdvTarget.TargetWallY = c.AdvTarget.TargetWallX
     c.AdvTarget.TargetWallZ = 7 * u.mm
+    c.AdvTarget.AluFrameX = 60 * u.cm
+    c.AdvTarget.AluFrameY = 60 * u.cm
+    c.AdvTarget.AluFrameZ = 7 * u.mm
 
     # Target Tracking stations
-    c.AdvTarget.TTX = 49.29 * u.cm
-    c.AdvTarget.TTY = 49.29 * u.cm
-    c.AdvTarget.TTZ = 8 * u.mm
-    c.AdvTarget.nTT = 100
+    c.AdvTarget.TTX = 45 * u.cm
+    c.AdvTarget.TTY = c.AdvTarget.TTX
+    c.AdvTarget.TTZ = 4 * u.mm
+    c.AdvTarget.nTT = 58
+    
 
     # AdvSND MuFilter structure
     """
@@ -679,55 +683,16 @@ with ConfigRegistry.register_config("basic") as c:
 
     # AdvSND MuFilter Layout 2 (SQUARED)
     c.AdvMuFilter = AttrDict(z=0 * u.cm)
-    c.AdvMuFilter.MuonSysPlaneX = 60.0 * u.cm
+    c.AdvMuFilter.MuonSysPlaneX = 45 * u.cm
     c.AdvMuFilter.MuonSysPlaneY = c.AdvMuFilter.MuonSysPlaneX
-    c.AdvMuFilter.CutOffset = 3.0 * u.cm
-    # c.AdvMuFilter.FeX               = 160.0 * u.cm
-    # c.AdvMuFilter.FeY               = 166.0 * u.cm #= c.AdvMuFilter.FeX
-    c.AdvMuFilter.FeZ = 8.0 * u.cm
-    c.AdvMuFilter.FeGap = 2.0 * u.cm
-    c.AdvMuFilter.Nplanes = 22
-    c.AdvMuFilter.CoilX = c.AdvMuFilter.MuonSysPlaneX
-    c.AdvMuFilter.CoilY = 9.2 * u.cm
-    c.AdvMuFilter.FeX = 2 * c.AdvMuFilter.MuonSysPlaneX
-    c.AdvMuFilter.FeY = 2 * c.AdvMuFilter.MuonSysPlaneY + 3 * c.AdvMuFilter.CoilY
+    c.AdvMuFilter.MuonSysPlaneZ = 4 * u.mm
+    c.AdvMuFilter.FeX = 105 * u.cm
+    c.AdvMuFilter.FeY = 80.0 * u.cm
+    c.AdvMuFilter.FeZ = 5 * u.cm
+    c.AdvMuFilter.FeGap = 7.5 * u.cm
+    c.AdvMuFilter.Nplanes = 34
+    c.AdvMuFilter.CoilX = 41 * u.cm
+    c.AdvMuFilter.CoilY = c.AdvMuFilter.MuonSysPlaneY
+    c.AdvMuFilter.CoilZ = 5 * u.cm
     c.AdvMuFilter.Field = 1.75 * u.tesla
-    c.AdvMuFilter.NBars = 20
-    c.AdvMuFilter.BarGap = 0.1 * u.mm
-    # AdvSND Downstream magnet
-    c.AdvMuFilter.DownCutOffset = 30.0 * u.cm
-    c.AdvMuFilter.DownFeZ = 160.0 * u.cm
-    c.AdvMuFilter.CoilThickY = 9.2 * u.cm
-    (
-        c.AdvMuFilter.MagTracker1X,
-        c.AdvMuFilter.MagTracker2X,
-        c.AdvMuFilter.MagTracker3X,
-    ) = 60 * u.cm, 70 * u.cm, 90 * u.cm
-    (
-        c.AdvMuFilter.MagTracker1Y,
-        c.AdvMuFilter.MagTracker2Y,
-        c.AdvMuFilter.MagTracker3Y,
-    ) = (
-        c.AdvMuFilter.MagTracker1X,
-        c.AdvMuFilter.MagTracker2X,
-        c.AdvMuFilter.MagTracker3X,
-    )
-    c.AdvMuFilter.MagTrackerZ = 25 * u.mm
-    # c.AdvMuFilter.DownFeX           = 200. * u.cm
-    # c.AdvMuFilter.DownFeY           = 228. * u.cm
-    c.AdvMuFilter.DownFeX = (200.0 / 120.0) * c.AdvMuFilter.MagTracker3X
-    c.AdvMuFilter.DownFeY = (228.0 / 120.0) * c.AdvMuFilter.MagTracker3Y
-    c.AdvMuFilter.DownFeYokeX = (
-        c.AdvMuFilter.DownFeX - c.AdvMuFilter.MagTracker2X
-    ) / 2.0
-    c.AdvMuFilter.DownFeYokeY = (
-        c.AdvMuFilter.DownFeY - c.AdvMuFilter.MagTracker2Y - c.AdvMuFilter.CoilThickY
-    ) / 2.0
-    c.AdvMuFilter.DownFeCutX = c.AdvMuFilter.DownFeYokeX - c.AdvMuFilter.DownCutOffset
-    c.AdvMuFilter.DownFeCutY = c.AdvMuFilter.DownFeYokeY - c.AdvMuFilter.DownCutOffset
-    c.AdvMuFilter.IronCoreZ = c.AdvMuFilter.DownFeZ
-    c.AdvMuFilter.IronCoreX1 = c.AdvMuFilter.MagTracker2X
-    c.AdvMuFilter.IronCoreX2 = c.AdvMuFilter.MagTracker3X
-    c.AdvMuFilter.IronCoreY1 = c.AdvMuFilter.IronCoreX1
-    c.AdvMuFilter.IronCoreY2 = c.AdvMuFilter.IronCoreX2
-    c.AdvMuFilter.DownField = 1.75 * u.tesla
+    c.AdvMuFilter.CurvRadius = 4.5 * u.cm

--- a/geometry/AdvSND_geom_config.py
+++ b/geometry/AdvSND_geom_config.py
@@ -3,6 +3,11 @@
 import shipunit as u
 from ShipGeoConfig import AttrDict, ConfigRegistry
 
+if "stagger_hcal" in globals():
+    stagger_hcal = globals()["stagger_hcal"]
+else:
+    stagger_hcal = False
+
 with ConfigRegistry.register_config("basic") as c:
     # cave parameters
     c.cave = AttrDict(z=0 * u.cm)
@@ -703,3 +708,6 @@ with ConfigRegistry.register_config("basic") as c:
     c.AdvMuFilter.CoilZ = 5.5 * u.cm
     c.AdvMuFilter.Field = 1.75 * u.tesla
     c.AdvMuFilter.CurvRadius = 6.5 * u.cm
+    # Staggering of XY HCAL layers
+    if stagger_hcal:
+        c.AdvMuFilter.stagger_step = 7.5 * u.mm

--- a/geometry/AdvSND_geom_config.py
+++ b/geometry/AdvSND_geom_config.py
@@ -655,19 +655,25 @@ with ConfigRegistry.register_config("basic") as c:
 
     # AdvSND Target & Tracker structure
     c.AdvTarget = AttrDict(z=0 * u.cm)
-    c.AdvTarget.TargetWallX = 40 * u.cm
-    c.AdvTarget.TargetWallY = c.AdvTarget.TargetWallX
-    c.AdvTarget.TargetWallZ = 7 * u.mm
-    c.AdvTarget.AluFrameX = 60 * u.cm
-    c.AdvTarget.AluFrameY = 60 * u.cm
-    c.AdvTarget.AluFrameZ = 7 * u.mm
+    # Tungsten plates
+    c.AdvTarget.PlateX = 45 * u.cm
+    c.AdvTarget.PlateY = c.AdvTarget.PlateX
+    c.AdvTarget.PlateZ = 7 * u.mm
+    # Support frame of the plates
+    c.AdvTarget.PlateFrameX = 60 * u.cm
+    c.AdvTarget.PlateFrameY = 60 * u.cm
+    c.AdvTarget.PlateFrameZ = c.AdvTarget.PlateZ
 
-    # Target Tracking stations
-    c.AdvTarget.TTX = 40 * u.cm
-    c.AdvTarget.TTY = c.AdvTarget.TTX
-    c.AdvTarget.TTZ = 4 * u.mm
+    # Target Tracking layers
+    c.AdvTarget.TTZ = (
+        4 * u.mm
+    )  # due to module overlaps, the thickness of a layer is actually 2x4mm
     c.AdvTarget.nTT = 58
-    
+
+    # Full target volume including inactive area
+    c.AdvTarget.X = 59 * u.cm
+    c.AdvTarget.Y = c.AdvTarget.X
+    c.AdvTarget.Z = c.AdvTarget.nTT * (2 * c.AdvTarget.TTZ + c.AdvTarget.PlateZ)
 
     # AdvSND MuFilter structure
     """
@@ -681,16 +687,17 @@ with ConfigRegistry.register_config("basic") as c:
         c.AdvMuFilter.nPlanes = 22
         """
 
-    # AdvSND MuFilter Layout 2 (SQUARED)
+    # AdvSND MuFilter
     c.AdvMuFilter = AttrDict(z=0 * u.cm)
-    c.AdvMuFilter.MuonSysPlaneX = 40 * u.cm
+    c.AdvMuFilter.MuonSysPlaneX = 60 * u.cm
     c.AdvMuFilter.MuonSysPlaneY = c.AdvMuFilter.MuonSysPlaneX
-    c.AdvMuFilter.MuonSysPlaneZ = 4 * u.mm
+    c.AdvMuFilter.MuonSysPlaneZ = (
+        4 * u.mm
+    )  # due to module overlaps, the thickness of a layer is actually 2x4mm
     c.AdvMuFilter.FeX = 115.1 * u.cm
     c.AdvMuFilter.FeY = 80.0 * u.cm
     c.AdvMuFilter.FeZ = 5 * u.cm
     c.AdvMuFilter.FeGap = 15.5 * u.cm
-    c.AdvMuFilter.Nplanes = 34
     c.AdvMuFilter.CoilX = 40 * u.cm
     c.AdvMuFilter.CoilY = c.AdvMuFilter.MuonSysPlaneY
     c.AdvMuFilter.CoilZ = 5.5 * u.cm

--- a/shipLHC/AdvMuFilter.cxx
+++ b/shipLHC/AdvMuFilter.cxx
@@ -160,6 +160,9 @@ void AdvMuFilter::ConstructGeometry()
     Double_t fFeYokeX = (fFeX-fMuonSysPlaneX-2*fFeGap)/2.;
     Double_t fFeYokeY = (fFeY-fMuonSysPlaneY)/2.;
 
+    LOG(INFO) << " CoilX: " << fCoilX << " cm" << endl;
+    LOG(INFO) << " FeYokeX: " << fFeYokeX << " cm" << endl;
+    LOG(INFO) << " FeYokeY: " << fFeYokeY << " cm" << endl;
 
     TGeoVolumeAssembly *volAdvMuFilter = new TGeoVolumeAssembly("volAdvMuFilter");
 
@@ -177,7 +180,7 @@ void AdvMuFilter::ConstructGeometry()
                       new TGeoTranslation(-2.4244059999999976 - EmWall0_survey.X(),
                                           38.3,
                                           354.862 + 3 + 1 + fFeZ / 2. - 41.895793 + 1. - 3.854227000000008
-                                              + 3.7497190000000046 - 64.414875));   // hardcoded, try to find and elegant solution
+                                              + 3.7497190000000046 - 64.44596200000001));   // hardcoded, try to find and elegant solution
     
     // Iron and Detector's shapes
     TGeoBBox *FeBlock = new TGeoBBox("FeBlock", fFeX/2., fFeY/2., fFeZ/2.);

--- a/shipLHC/AdvMuFilter.cxx
+++ b/shipLHC/AdvMuFilter.cxx
@@ -180,7 +180,7 @@ void AdvMuFilter::ConstructGeometry()
 
     detector->AddNode(volAdvMuFilter,
                       0,
-                      new TGeoTranslation(-2.4244059999999976 - EmWall0_survey.X(),
+                      new TGeoTranslation(-2.4244059999999976 - EmWall0_survey.X() - 1.1,
                                           38.3,
                                           354.862 + 3 + 1 + fFeZ / 2. - 41.895793 + 1. - 3.854227000000008
                                               + 3.7497190000000046

--- a/shipLHC/AdvMuFilter.cxx
+++ b/shipLHC/AdvMuFilter.cxx
@@ -1,6 +1,9 @@
 //
 //  AdvMuFilter.cxx
 //
+//  S.Ilieva
+//  March 2025
+//
 //  by D. Centanni and O. Lantwin
 //  2024
 //
@@ -130,9 +133,6 @@ void AdvMuFilter::ConstructGeometry()
     InitMedium("iron");
     TGeoMedium *Fe = gGeoManager->GetMedium("iron");
 
-    InitMedium("polyvinyltoluene");
-    TGeoMedium *Scint = gGeoManager->GetMedium("polyvinyltoluene");
-
     InitMedium("CoilCopper");
     TGeoMedium *Cu = gGeoManager->GetMedium("CoilCopper");
 
@@ -143,7 +143,10 @@ void AdvMuFilter::ConstructGeometry()
     TGeoMedium *Al = gGeoManager->GetMedium("aluminium");
 
     InitMedium("silicon");
-    TGeoMedium *Silicon = gGeoManager->GetMedium("silicon");
+    TGeoMedium *silicon = gGeoManager->GetMedium("silicon");
+
+    InitMedium("steel");
+    TGeoMedium *steel = gGeoManager->GetMedium("steel");
 
     Double_t fMuonSysPlaneX = conf_floats["AdvMuFilter/MuonSysPlaneX"];
     Double_t fMuonSysPlaneY = conf_floats["AdvMuFilter/MuonSysPlaneY"];
@@ -153,12 +156,12 @@ void AdvMuFilter::ConstructGeometry()
     Double_t fFeZ = conf_floats["AdvMuFilter/FeZ"];
     Double_t fFeGap = conf_floats["AdvMuFilter/FeGap"];
     Double_t fCurvRadius = conf_floats["AdvMuFilter/CurvRadius"];
-    Int_t fNplanes = conf_ints["AdvMuFilter/Nplanes"];
+    Int_t fNlayers = advsnd::hcal::n_XY_layers + advsnd::hcal::n_X_layers;
     Double_t fCoilZ = conf_floats["AdvMuFilter/CoilZ"];
     Double_t fCoilY = conf_floats["AdvMuFilter/CoilY"];
-    Double_t fCoilX = fMuonSysPlaneX+2*fFeGap-2*(fCoilZ+fCurvRadius);
-    Double_t fFeYokeX = (fFeX-fMuonSysPlaneX-2*fFeGap)/2.;
-    Double_t fFeYokeY = (fFeY-fMuonSysPlaneY)/2.;
+    Double_t fCoilX = fMuonSysPlaneX + 2 * fFeGap - 2 * (fCoilZ + fCurvRadius);
+    Double_t fFeYokeX = (fFeX - fMuonSysPlaneX - 2 * fFeGap) / 2.;
+    Double_t fFeYokeY = (fFeY - fMuonSysPlaneY) / 2.;
 
     LOG(INFO) << " CoilX: " << fCoilX << " cm" << endl;
     LOG(INFO) << " FeYokeX: " << fFeYokeX << " cm" << endl;
@@ -180,68 +183,163 @@ void AdvMuFilter::ConstructGeometry()
                       new TGeoTranslation(-2.4244059999999976 - EmWall0_survey.X(),
                                           38.3,
                                           354.862 + 3 + 1 + fFeZ / 2. - 41.895793 + 1. - 3.854227000000008
-                                              + 3.7497190000000046 - 64.44596200000001));   // hardcoded, try to find and elegant solution
-    
+                                              + 3.7497190000000046
+                                              - 64.44596200000001));   // hardcoded, try to find and elegant solution
+
     // Iron and Detector's shapes
-    TGeoBBox *FeBlock = new TGeoBBox("FeBlock", fFeX/2., fFeY/2., fFeZ/2.);
-    TGeoBBox *FeGap   = new TGeoBBox("FeGap", (2*fFeGap+fMuonSysPlaneX)/2, fMuonSysPlaneY/2., fFeZ/2.+0.001);
+    TGeoBBox *FeBlock = new TGeoBBox("FeBlock", fFeX / 2., fFeY / 2., fFeZ / 2.);
+    TGeoBBox *FeGap = new TGeoBBox("FeGap", (2 * fFeGap + fMuonSysPlaneX) / 2, fMuonSysPlaneY / 2., fFeZ / 2. + 1e-10);
     TGeoCompositeShape *FeSlab = new TGeoCompositeShape("FeSlab", "FeBlock-FeGap");
-    TGeoBBox *MagFe   = new TGeoBBox("MagFe", fMuonSysPlaneX/2., fMuonSysPlaneY/2., fFeZ/2.);
-    TGeoBBox *MuonSysPlane   = new TGeoBBox("MuonSysPlane", fMuonSysPlaneX/2., fMuonSysPlaneY/2., fMuonSysPlaneZ/2.);
+    TGeoBBox *MagnetizedFe = new TGeoBBox("MagnetizedFe", fMuonSysPlaneX / 2., fMuonSysPlaneY / 2., fFeZ / 2.);
 
     // Coil shapes
-    TGeoBBox *FrontCoil = new TGeoBBox("FrontCoil", fCoilX/2., fCoilY/2., fCoilZ/2.);
-    TGeoBBox *LatCoil = new TGeoBBox("LatCoil", fCoilZ/2., fCoilY/2., fNplanes*(fFeZ+2*fMuonSysPlaneZ)/2.);
-    TGeoTubeSeg *CurvCoil = new TGeoTubeSeg("CurvCoil", fCurvRadius, fCurvRadius+fCoilZ, fCoilY/2., 0, 90);
+    TGeoBBox *FrontCoil = new TGeoBBox("FrontCoil", fCoilX / 2., fCoilY / 2., fCoilZ / 2.);
+    TGeoBBox *LatCoil = new TGeoBBox("LatCoil", fCoilZ / 2., fCoilY / 2., fNlayers * (fFeZ + 2 * fMuonSysPlaneZ) / 2.);
+    TGeoTubeSeg *CurvCoil = new TGeoTubeSeg("CurvCoil", fCurvRadius, fCurvRadius + fCoilZ, fCoilY / 2., 0, 90);
 
-    TGeoCombiTrans *Left = new TGeoCombiTrans(TGeoTranslation(-fCoilX/2., 0, -(fCoilZ+fCurvRadius)/2.-fCurvRadius/2.), TGeoRotation("rot1", 0, 90, 90));
+    TGeoCombiTrans *Left =
+        new TGeoCombiTrans(TGeoTranslation(-fCoilX / 2., 0, -(fCoilZ + fCurvRadius) / 2. - fCurvRadius / 2.),
+                           TGeoRotation("rot1", 0, 90, 90));
     Left->SetName("Left");
     Left->RegisterYourself();
-    TGeoCombiTrans *Right = new TGeoCombiTrans(TGeoTranslation(+fCoilX/2., 0, -(fCoilZ+fCurvRadius)/2.-fCurvRadius/2.), TGeoRotation("rot2", 0, 90, 0));
+    TGeoCombiTrans *Right =
+        new TGeoCombiTrans(TGeoTranslation(+fCoilX / 2., 0, -(fCoilZ + fCurvRadius) / 2. - fCurvRadius / 2.),
+                           TGeoRotation("rot2", 0, 90, 0));
     Right->SetName("Right");
     Right->RegisterYourself();
-    TGeoCompositeShape *FrontCoilShape = new TGeoCompositeShape("FrontCoilShape", "FrontCoil+(CurvCoil:Left)+(CurvCoil:Right)");
+    TGeoCompositeShape *FrontCoilShape =
+        new TGeoCompositeShape("FrontCoilShape", "FrontCoil+(CurvCoil:Left)+(CurvCoil:Right)");
 
     TGeoVolume *volFrontCoil = new TGeoVolume("volFrontCoil", FrontCoilShape, Cu);
-    volFrontCoil->SetLineColor(kOrange+1);
-    volAdvMuFilter->AddNode(volFrontCoil, 0, new TGeoCombiTrans(TGeoTranslation(0, 0, fCoilZ/2.), TGeoRotation("rot3", 0, 180, 0)));
-    volAdvMuFilter->AddNode(volFrontCoil, 1, new TGeoTranslation(0, 0, fCoilZ+2*fCurvRadius+fCoilZ/2.+fNplanes*(fFeZ+2*fMuonSysPlaneZ)));
-    TGeoTranslation *LatLeft = new TGeoTranslation(-fCoilX/2.-fCoilZ/2.-fCurvRadius, 0, 0);
+    volFrontCoil->SetLineColor(kOrange + 1);
+    volAdvMuFilter->AddNode(
+        volFrontCoil, 0, new TGeoCombiTrans(TGeoTranslation(0, 0, fCoilZ / 2.), TGeoRotation("rot3", 0, 180, 0)));
+    volAdvMuFilter->AddNode(
+        volFrontCoil,
+        1,
+        new TGeoTranslation(0, 0, fCoilZ + 2 * fCurvRadius + fCoilZ / 2. + fNlayers * (fFeZ + 2 * fMuonSysPlaneZ)));
+    TGeoTranslation *LatLeft = new TGeoTranslation(-fCoilX / 2. - fCoilZ / 2. - fCurvRadius, 0, 0);
     LatLeft->SetName("LatLeft");
     LatLeft->RegisterYourself();
-    TGeoTranslation *LatRight = new TGeoTranslation(+fCoilX/2.+fCoilZ/2.+fCurvRadius, 0, 0);
+    TGeoTranslation *LatRight = new TGeoTranslation(+fCoilX / 2. + fCoilZ / 2. + fCurvRadius, 0, 0);
     LatRight->SetName("LatRight");
     LatRight->RegisterYourself();
     TGeoCompositeShape *LatCoilShape = new TGeoCompositeShape("LatCoilShape", "(LatCoil:LatLeft)+(LatCoil:LatRight)");
     TGeoVolume *volLatCoil = new TGeoVolume("volLatCoil", LatCoilShape, Cu);
-    volLatCoil->SetLineColor(kOrange+1);
-    volAdvMuFilter->AddNode(volLatCoil, 0, new TGeoTranslation(0, 0, fCoilZ+fCurvRadius+(fNplanes/2)*(fFeZ+2*fMuonSysPlaneZ)));
+    volLatCoil->SetLineColor(kOrange + 1);
+    volAdvMuFilter->AddNode(
+        volLatCoil, 0, new TGeoTranslation(0, 0, fCoilZ + fCurvRadius + (fNlayers / 2.) * (fFeZ + 2 * fMuonSysPlaneZ)));
 
-    TGeoVolume *volMuonSysPlane = new TGeoVolume("volMuonSysPlane", MuonSysPlane, Silicon);
-    AddSensitiveVolume(volMuonSysPlane);
     TGeoVolume *volFeSlab = new TGeoVolume("volFeSlab", FeSlab, Fe);
-    TGeoVolume *volMagFe = new TGeoVolume("volMagFe", MagFe, Fe);
+    TGeoVolume *volMagnetizedFe = new TGeoVolume("volMagnetizedFe", MagnetizedFe, Fe);
 
     Double_t fField = conf_floats["AdvMuFilter/Field"];
-    LOG(INFO) << " Mag field: " << fField / 10. << " Tesla" << endl;
+    LOG(INFO) << " Magnetic field: " << fField / 10. << " Tesla" << endl;
     TGeoUniformMagField *magField = new TGeoUniformMagField(0, fField, 0);
     TGeoGlobalMagField::Instance()->SetField(magField);
-    volMagFe->SetField(magField);
+    volMagnetizedFe->SetField(magField);
 
-    volMuonSysPlane->SetLineColor(kGray-2);
-    volFeSlab->SetLineColor(kGreen-4);
-    volMagFe->SetLineColor(kGreen);
+    volFeSlab->SetLineColor(kGreen - 4);
+    volMagnetizedFe->SetLineColor(kGreen);
 
-    volAdvMuFilter->AddNode(volMuonSysPlane, 0, new TGeoTranslation(0, 0, fMuonSysPlaneZ/2+(fCoilZ+fCurvRadius)));
-    for (auto plane = 1; plane<fNplanes+1; plane++) {
-        Double_t station_length = 2*fMuonSysPlaneZ+fFeZ;
-        Double_t Zshift = fMuonSysPlaneZ+fCoilZ+fCurvRadius;
-        volAdvMuFilter->AddNode(volFeSlab, plane, new TGeoTranslation(0, 0, Zshift+fFeZ/2+(plane-1)*station_length));
-        volAdvMuFilter->AddNode(volMagFe, plane, new TGeoTranslation(0, 0, Zshift+fFeZ/2+(plane-1)*station_length));
-        volAdvMuFilter->AddNode(volMuonSysPlane, plane*10, new TGeoTranslation(0, 0, Zshift+fFeZ+fMuonSysPlaneZ/2+(plane-1)*station_length));
-        if (plane == fNplanes) continue;
-        volAdvMuFilter->AddNode(volMuonSysPlane, plane*10+1, new TGeoTranslation(0, 0, Zshift+fFeZ+fMuonSysPlaneZ+fMuonSysPlaneZ/2+(plane-1)*station_length));
-    }
+    // No excavation case with smaller HCAL layers. The silicon strip modules are identical to the target ones.
+    // Silicon tracker module
+    //
+    // See https://indico.cern.ch/event/1452210/contributions/6134180/attachments/2934314/5153496/Abbaneo_Sep2024.pdf
+    // for graphical layout
+    //
+    // Passive part - support with a hole to host the sensors.
+    // The support is on 4 legs, which wont be modelled for now. Instead the support_thickness is doubled (2x0.5mm) to
+    // approximate.
+    TGeoBBox *SupportPlate = new TGeoBBox(
+        "SupportPlate", advsnd::module_width / 2, advsnd::module_length / 2, advsnd::support_thickness / 2);
+    float support_hole_x_half_dim = (2 * advsnd::sensor_width + advsnd::sensor_gap) / 2.;
+    TGeoBBox *SupportHole = new TGeoBBox(
+        "SupportHole", support_hole_x_half_dim, advsnd::sensor_length / 2, advsnd::support_thickness / 2 + 1e-10);
+    TGeoTranslation *t1 = new TGeoTranslation(
+        "t1", -advsnd::module_width / 2 + advsnd::target::module_dead_space_side_small + support_hole_x_half_dim, 0, 0);
+    t1->RegisterYourself();
+    TGeoCompositeShape *Support = new TGeoCompositeShape("Support", "SupportPlate-SupportHole:t1");
+
+    TGeoVolume *SupportVolume = new TGeoVolume("SupportVolume", Support, Polystyrene);
+    SupportVolume->SetLineColor(kGray);
+    SupportVolume->SetTransparency(20);
+    // Active part  - sensors of Si strips
+    // Strips are not included in the geometry since it will become much more computationally heavy
+    TGeoBBox *SensorShape =
+        new TGeoBBox("SensorShape", advsnd::sensor_width / 2, advsnd::sensor_length / 2, advsnd::sensor_thickness / 2);
+    TGeoVolume *SensorVolume = new TGeoVolume("HCAL_SensorVolume", SensorShape, silicon);
+    SensorVolume->SetLineColor(kAzure + 3);
+    AddSensitiveVolume(SensorVolume);
+
+    // Useful dimensions when placing detector elements
+    float Zshift = fMuonSysPlaneZ + fCoilZ + fCurvRadius;
+    float layer_DX = (2 * advsnd::module_width + advsnd::hcal::modules_column_gap) / 2;
+    float layer_DY = (4 * advsnd::module_length - 3 * advsnd::hcal::modules_rows_overlap) / 2;
+    float Fe_and_layer_z = fFeZ + 2 * fMuonSysPlaneZ;
+
+    for (auto &&layer : TSeq(fNlayers)) {
+        // if (i == fNlayers - 1)
+        //     continue;
+
+        TGeoVolumeAssembly *ActiveLayer = new TGeoVolumeAssembly("HCAL_Layer");
+        int plane = (layer < advsnd::hcal::n_XY_layers) ? layer % advsnd::hcal::planes : 1;
+        // Each plane consists of row x columns = 4x2 modules
+        int i = 0;
+        for (auto &&row : TSeq(advsnd::hcal::rows)) {
+            for (auto &&column : TSeq(advsnd::hcal::columns)) {
+                // Each module in turn consists of two sensors on a support
+                TGeoVolumeAssembly *SensorModule = new TGeoVolumeAssembly("SensorModule");
+                SensorModule->AddNode(
+                    SupportVolume, 1, new TGeoTranslation(0, 0, fMuonSysPlaneZ - advsnd::support_thickness / 2));
+                for (auto &&sensor : TSeq(advsnd::sensors)) {
+                    int32_t sensor_id =
+                        (layer << 17) + (plane << 16) + (row << 13) + (column << 11) + (sensor << 10) + 999;
+                    SensorModule->AddNode(
+                        SensorVolume,
+                        sensor_id,
+                        new TGeoTranslation(-advsnd::module_width / 2 + advsnd::hcal::module_dead_space_side_small
+                                                + advsnd::sensor_width / 2
+                                                + sensor * (advsnd::sensor_width + advsnd::sensor_gap),
+                                            -advsnd::module_length / 2 + advsnd::hcal::module_dead_space_bottom
+                                                + advsnd::sensor_length / 2,
+                                            fMuonSysPlaneZ - advsnd::support_thickness - advsnd::sensor_thickness / 2));
+                }
+                ActiveLayer->AddNode(
+                    SensorModule,
+                    ++i,
+                    new TGeoCombiTrans(
+                        // Offset modules as needed by column and rotate
+                        TGeoTranslation(
+                            (column % 2 ? -1 : 1) * (advsnd::module_width / 2 + advsnd::hcal::modules_column_gap / 2),
+                            (row + 1) * advsnd::module_length / 2
+                                + +row * (advsnd::module_length / 2 - advsnd::hcal::modules_rows_overlap),
+                            fMuonSysPlaneZ),   // modules facing one another are offset by the module_thickness, leaving
+                                               // some clearance(air) for electronics
+                        // Rotate every module of the first column by 180 on z axis and
+                        // rotate every other row by 180 deg on y axis to arrive at back-to-front layout
+                        TGeoRotation(TString::Format("rot%d", i), 0, (row % 2 ? 180 : 0), (column % 2 ? 180 : 0))));
+            }   // columns
+        }   // rows
+        // Alternate iron slabs followed by a detecting layer
+        // Offsets in Y are adjusted so that the center of the whole detector is positioned at 0
+        volAdvMuFilter->AddNode(
+            volFeSlab, layer, new TGeoTranslation(0, 0, Zshift + fFeZ / 2 + layer * Fe_and_layer_z));
+        volAdvMuFilter->AddNode(
+            volMagnetizedFe, layer, new TGeoTranslation(0, 0, Zshift + fFeZ / 2 + layer * Fe_and_layer_z));
+        if (plane == 0) {
+            // Y-plane (horizontal strips along y axis)
+            volAdvMuFilter->AddNode(
+                ActiveLayer, layer, new TGeoTranslation(0, -layer_DY, Zshift + fFeZ + layer * Fe_and_layer_z));
+        } else if (plane == 1) {
+            // X-plane (vertical strips along x axis)
+            volAdvMuFilter->AddNode(
+                ActiveLayer,
+                layer,
+                new TGeoCombiTrans(TGeoTranslation(layer_DY, 0, Zshift + fFeZ + layer * Fe_and_layer_z),
+                                   TGeoRotation("y_rot", 0, 0, 90)));
+        }
+    }   // layers
 }
 Bool_t AdvMuFilter::ProcessHits(FairVolume *vol)
 {
@@ -303,26 +401,22 @@ void AdvMuFilter::GetPosition(Int_t detID, TVector3 &A, TVector3 &B)
     int strip = (detID) % 1024;                // actual strip ID
     int geofile_detID = detID - strip + 999;   // the det id number needed to read the geometry
 
-    int station = geofile_detID >> 17;
-    int plane = (geofile_detID >> 16) % 2;
+    int layer = geofile_detID >> 17;
     int row = (geofile_detID >> 13) % 8;
     int column = (geofile_detID >> 11) % 4;
     int sensor = geofile_detID;
-    int sensor_module = advsnd::muon::columns * row + 1 + column;
+    int sensor_module = advsnd::hcal::columns * row + 1 + column;
 
-    double global_pos[3];
     double local_pos[3] = {0, 0, 0};
     TString path = TString::Format("/cave_1/"
-                                    "Detector_0/"
-                                    "volAdvMuFilter_0/"
-                                    "TrackingStation_%d/"
-                                    "TrackerPlane_%d/"
-                                    "SensorModule_%d/"
-                                    "SensorVolumeFilter_%d",
-                                    station,
-                                    plane,
-                                    sensor_module,
-                                    sensor);
+                                   "Detector_0/"
+                                   "volAdvMuFilter_0/"
+                                   "HCAL_Layer_%d/"
+                                   "SensorModule_%d/"
+                                   "HCAL_SensorVolume_%d",
+                                   layer,
+                                   sensor_module,
+                                   sensor);
 
     TGeoNavigator *nav = gGeoManager->GetCurrentNavigator();
     if (nav->CheckPath(path)) {
@@ -334,14 +428,14 @@ void AdvMuFilter::GetPosition(Int_t detID, TVector3 &A, TVector3 &B)
     TGeoNode *W = nav->GetCurrentNode();
     TGeoBBox *S = dynamic_cast<TGeoBBox *>(W->GetVolume()->GetShape());
     // knowing the strip, get the postion along the sensor
-    local_pos[0] = (strip - (advsnd::strips / 2)) * (advsnd::sensor_width / advsnd::strips);
-    Double_t top_pos[3] = {local_pos[0], S->GetDY(), 0};
-    Double_t bot_pos[3] = {local_pos[0], -(S->GetDY()), 0};
-    Double_t global_top_pos[3], global_bot_pos[3];
-    nav->LocalToMaster(top_pos, global_top_pos);
-    nav->LocalToMaster(bot_pos, global_bot_pos);
-    A.SetXYZ(global_top_pos[0], global_top_pos[1], global_top_pos[2]);
-    B.SetXYZ(global_bot_pos[0], global_bot_pos[1], global_bot_pos[2]);
+    local_pos[1] = (strip - (advsnd::strips / 2)) * (advsnd::sensor_length / advsnd::strips);
+    Double_t left_pos[3] = {S->GetDX(), local_pos[1], 0};
+    Double_t right_pos[3] = {-(S->GetDX()), local_pos[1], 0};
+    Double_t global_left_pos[3], global_right_pos[3];
+    nav->LocalToMaster(left_pos, global_left_pos);
+    nav->LocalToMaster(right_pos, global_right_pos);
+    A.SetXYZ(global_left_pos[0], global_left_pos[1], global_left_pos[2]);
+    B.SetXYZ(global_right_pos[0], global_right_pos[1], global_right_pos[2]);
 }
 
 void AdvMuFilter::EndOfEvent() { fAdvMuFilterPointCollection->Clear(); }

--- a/shipLHC/AdvMuFilterHit.h
+++ b/shipLHC/AdvMuFilterHit.h
@@ -24,14 +24,14 @@ class AdvMuFilterHit : public SndlhcHit
     bool isValid() const { return flag; }
     bool isMasked(Int_t i) const { return fMasked[i]; }
     void SetMasked(Int_t i) { fMasked[i] = kTRUE; }
-    int constexpr GetStation() { return fDetectorID >> 17; }
+    int constexpr GetLayer() { return fDetectorID >> 17; }
     int constexpr GetPlane() { return (fDetectorID >> 16) % 2; }   // 0 is X-plane, 1 is Y-pane
     int constexpr GetRow() { return (fDetectorID >> 13) % 8; }
     int constexpr GetColumn() { return (fDetectorID >> 11) % 4; }
     int constexpr GetSensor() { return (fDetectorID >> 10) % 2; }
     int constexpr GetStrip() { return (fDetectorID) % 1024; }
-    int constexpr GetModule() { return advsnd::muon::columns * GetRow() + 1 + GetColumn(); }
-    bool constexpr isVertical() { return GetPlane() == 0; };
+    int constexpr GetModule() { return advsnd::hcal::columns * GetRow() + 1 + GetColumn(); }
+    bool constexpr isVertical() { return GetPlane() == 1; };
 
   private:
     bool flag;          ///< flag

--- a/shipLHC/AdvMuFilterPoint.h
+++ b/shipLHC/AdvMuFilterPoint.h
@@ -39,14 +39,14 @@ class AdvMuFilterPoint : public FairMCPoint
     virtual void Print(const Option_t* opt) const;
 
     Int_t PdgCode() const { return fPdgCode; }
-    int constexpr GetStation() { return fDetectorID >> 17; }
+    int constexpr GetLayer() { return fDetectorID >> 17; }
     int constexpr GetPlane() { return (fDetectorID >> 16) % 2; }   // 0 is X-plane, 1 is Y-pane
     int constexpr GetRow() { return (fDetectorID >> 13) % 8; }
     int constexpr GetColumn() { return (fDetectorID >> 11) % 4; }
     int constexpr GetSensor() { return (fDetectorID >> 10) % 2; }
     int constexpr GetStrip() { return (fDetectorID) % 1024; }
-    int constexpr GetModule() { return advsnd::muon::columns * GetRow() + 1 + GetColumn(); }
-    bool constexpr isVertical() { return GetPlane() == 0; };
+    int constexpr GetModule() { return advsnd::hcal::columns * GetRow() + 1 + GetColumn(); }
+    bool constexpr isVertical() { return GetPlane() == 1; };
 
   private:
     Int_t fPdgCode;

--- a/shipLHC/AdvTarget.cxx
+++ b/shipLHC/AdvTarget.cxx
@@ -158,7 +158,7 @@ void AdvTarget::ConstructGeometry()
     double line_of_sight_offset = (-2.4244059999999976 + 5.203625000000001) * cm;
     detector->AddNode(volAdvTarget,
                       0,
-                      new TGeoTranslation(line_of_sight_offset - EmWall0_survey.X() + (40 * cm - 42.2 * cm) / 2.,
+                      new TGeoTranslation(line_of_sight_offset - EmWall0_survey.X() + (40 * cm - 42.2 * cm) / 2. - 1.1,
                                           EmWall0_survey.Y(),
                                           -TargetDiff + EmWall0_survey.Z() - 60 * cm
                                               - 30 * cm));   // - 60 * cm - 30 * cm to allocate a 150 cm Target

--- a/shipLHC/AdvTargetHit.h
+++ b/shipLHC/AdvTargetHit.h
@@ -24,14 +24,14 @@ class AdvTargetHit : public SndlhcHit
     bool isValid() const { return flag; }
     bool isMasked(Int_t i) const { return fMasked[i]; }
     void SetMasked(Int_t i) { fMasked[i] = kTRUE; }
-    int constexpr GetStation() { return fDetectorID >> 17; }
+    int constexpr GetLayer() { return fDetectorID >> 17; }
     int constexpr GetPlane() { return (fDetectorID >> 16) % 2; }   // 0 is X-plane, 1 is Y-pane
     int constexpr GetRow() { return (fDetectorID >> 13) % 8; }
     int constexpr GetColumn() { return (fDetectorID >> 11) % 4; }
     int constexpr GetSensor() { return (fDetectorID >> 10) % 2; }
     int constexpr GetStrip() { return (fDetectorID) % 1024; }
     int constexpr GetModule() { return advsnd::target::columns * GetRow() + 1 + GetColumn(); }
-    bool constexpr isVertical() { return GetPlane() == 0; };
+    bool constexpr isVertical() { return GetPlane() == 1; };
 
   private:
     bool flag;          ///< flag

--- a/shipLHC/AdvTargetPoint.h
+++ b/shipLHC/AdvTargetPoint.h
@@ -42,14 +42,14 @@ class AdvTargetPoint : public FairMCPoint
     virtual void Print(const Option_t* opt) const;
 
     Int_t PdgCode() const { return fPdgCode; }
-    int constexpr GetStation() { return fDetectorID >> 17; }
+    int constexpr GetLayer() { return fDetectorID >> 17; }
     int constexpr GetPlane() { return (fDetectorID >> 16) % 2; }   // 0 is X-plane, 1 is Y-pane
     int constexpr GetRow() { return (fDetectorID >> 13) % 8; }
     int constexpr GetColumn() { return (fDetectorID >> 11) % 4; }
     int constexpr GetSensor() { return (fDetectorID >> 10) % 2; }
     int constexpr GetStrip() { return (fDetectorID) % 1024; }
     int constexpr GetModule() { return advsnd::target::columns * GetRow() + 1 + GetColumn(); }
-    bool constexpr IsVertical() { return GetPlane() == 0; };
+    bool constexpr IsVertical() { return GetPlane() == 1; };
     TVector3 GetEntryPoint() const { return TVector3(2 * fX - fExitX, 2 * fY - fExitY, 2 * fZ - fExitZ); }
     TVector3 GetExitPoint() const { return TVector3(fExitX, fExitY, fExitZ); }
 

--- a/shipLHC/Floor.cxx
+++ b/shipLHC/Floor.cxx
@@ -194,8 +194,8 @@ void Floor::ConstructGeometry()
          Double_t CurrentTargetY = 9.564471+5.368296; // current y coordinate of the target low edge, hardcoded due to time constraints, find better way
 
          Double_t ShiftX = TargetX/2.+0.0033519999999995775+2.;
-         Double_t ShiftY = -CurrentTargetY-20.188581+4;
-         Double_t ShiftZ = -400.;
+         Double_t ShiftY = -CurrentTargetY-20.188581+4+9.078588;
+         Double_t ShiftZ = -200;
          ////////////////////////////////////////////
          auto localSND_physCS_comb = new TGeoCombiTrans("localSND_physCS",0.+ShiftX,0.+ShiftY, 0.+ShiftZ,localSND_physCS_rot);    // origin is 480m downstream of IP1, shifting the apparatus 4m upstream
          localSND_physCS_comb->RegisterYourself();

--- a/shipLHC/Floor.cxx
+++ b/shipLHC/Floor.cxx
@@ -195,7 +195,7 @@ void Floor::ConstructGeometry()
 
          Double_t ShiftX = TargetX/2.+0.0033519999999995775-27;
          Double_t ShiftY = -CurrentTargetY+35.890007+0.5384230000000017;
-         Double_t ShiftZ = -200;
+         Double_t ShiftZ = -200+179;
          ////////////////////////////////////////////
          auto localSND_physCS_comb = new TGeoCombiTrans("localSND_physCS",0.+ShiftX,0.+ShiftY, 0.+ShiftZ,localSND_physCS_rot);    // origin is 480m downstream of IP1, shifting the apparatus 4m upstream
          localSND_physCS_comb->RegisterYourself();
@@ -369,13 +369,15 @@ void Floor::ConstructGeometry()
   /**** Hand changes to fit the AdvSND apparatus ****/ 
   //TVector3 detdim(89.998020, 107.989308, 362.541092+2.);
   //TVector3 detdim(99.997800+6, 113.988714+25, 281.160616+2.+50); // new 2024
-  TVector3 detdim(60, 100, 200); // new Aug 2024
+  TVector3 detdim(57.548733, 39.996040, 154.614972); // new Aug 2024
   //auto Detpos = new TGeoTranslation("Detpos", -0.2024000+ShiftX, 30.581334+ShiftY, 620.85947+ShiftZ);
-  auto Detpos = new TGeoTranslation("Detpos", ShiftX-99.997800/2+22., ShiftY+113.988714/2.-10, ShiftZ+2*279.160616-22.-250); // new 2024
+  //auto Detpos = new TGeoTranslation("Detpos", ShiftX-99.997800/2+22., ShiftY+113.988714/2.-10, ShiftZ+2*279.160616-22.-250); // new 2024
+  auto Detpos = new TGeoTranslation("Detpos", ShiftX-99.997800/2+22., ShiftY+113.988714/2.-10-9-4, ShiftZ+2*279.160616-22.-250); // new 2024
   Detpos->RegisterYourself();
   auto DetShape = new TGeoBBox("DetShape", detdim.X(), detdim.Y(), detdim.Z());
   /////////////////////////////////////////////
-  auto total = new TGeoCompositeShape("Stotal","TI18_1_union+TI18_2_union+TI18_3_union-DetShape:Detpos");
+  //auto total = new TGeoCompositeShape("Stotal","TI18_1_union+TI18_2_union+TI18_3_union-DetShape:Detpos");
+  auto total = new TGeoCompositeShape("Stotal","TI18_1_union+TI18_2_union+TI18_3_union");
   auto volT = new TGeoVolume("VTI18",total,concrete);
   volT->SetTransparency(50);
   volT->SetLineColor(kGray);
@@ -439,7 +441,7 @@ void Floor::ConstructGeometry()
   tunnel->AddNode(fluka,1, new TGeoTranslation(-350.,0,dz+zs- SND_Z-50.));  // move 50cm upstream to avoid overlap
 */
  TGeoBBox* RockDetShape = new TGeoBBox("RockDetShape", detdim.X()+30, detdim.Y()+30, detdim.Z()+180);
- auto RockDetpos = new TGeoTranslation("RockDetpos", ShiftX-99.997800/2+22., ShiftY+113.988714/2.-10, ShiftZ+2*279.160616); // new 2024
+ auto RockDetpos = new TGeoTranslation("RockDetpos", ShiftX-99.997800/2+22., ShiftY+113.988714/2.-10-20, ShiftZ+2*279.160616); // new 2024
  RockDetpos->RegisterYourself();
 
  double zs = 40900.;  // scoring plane
@@ -448,7 +450,8 @@ void Floor::ConstructGeometry()
  auto bigBox   = new TGeoBBox("BigBox", 1000.,1000. , dz);
  auto TR_1       = new TGeoTranslation("TR_1",0.,0.,-dz+geoParameters["TI18_o1"][2]-SND_Z - 50.); // move a bit more upstream to have free view from the back
  TR_1->RegisterYourself();
- auto cutOut   = new TGeoCompositeShape("cutOut", "BigBox:TR_1-Ftotal2-(TI18_1_Funion+TI18_2_Funion+TI18_3_Funion)-RockDetShape:RockDetpos");
+ //auto cutOut   = new TGeoCompositeShape("cutOut", "BigBox:TR_1-Ftotal2-(TI18_1_Funion+TI18_2_Funion+TI18_3_Funion)-RockDetShape:RockDetpos");
+ auto cutOut   = new TGeoCompositeShape("cutOut", "BigBox:TR_1-Ftotal2-(TI18_1_Funion+TI18_2_Funion+TI18_3_Funion)");
  auto volT3      = new TGeoVolume("Vrock",cutOut,rock);
  volT3->SetTransparency(75);
  volT3->SetLineColor(kRed);

--- a/shipLHC/Floor.cxx
+++ b/shipLHC/Floor.cxx
@@ -368,9 +368,10 @@ void Floor::ConstructGeometry()
   LOG(DEBUG) << "shapes "<<shapes[0]->GetName()<<" "<<shapes[1]->GetName()<<" "<<shapes[2]->GetName();
   /**** Hand changes to fit the AdvSND apparatus ****/ 
   //TVector3 detdim(89.998020, 107.989308, 362.541092+2.);
-  TVector3 detdim(99.997800+6, 113.988714+25, 281.160616+2.+70); // new 2024
+  //TVector3 detdim(99.997800+6, 113.988714+25, 281.160616+2.+50); // new 2024
+  TVector3 detdim(60, 100, 200); // new Aug 2024
   //auto Detpos = new TGeoTranslation("Detpos", -0.2024000+ShiftX, 30.581334+ShiftY, 620.85947+ShiftZ);
-  auto Detpos = new TGeoTranslation("Detpos", ShiftX-99.997800/2+22., ShiftY+113.988714/2.-10, ShiftZ+2*279.160616-22.-30); // new 2024
+  auto Detpos = new TGeoTranslation("Detpos", ShiftX-99.997800/2+22., ShiftY+113.988714/2.-10, ShiftZ+2*279.160616-22.-250); // new 2024
   Detpos->RegisterYourself();
   auto DetShape = new TGeoBBox("DetShape", detdim.X(), detdim.Y(), detdim.Z());
   /////////////////////////////////////////////

--- a/shipLHC/Floor.cxx
+++ b/shipLHC/Floor.cxx
@@ -193,8 +193,8 @@ void Floor::ConstructGeometry()
          Double_t TargetX = 50.0;
          Double_t CurrentTargetY = 9.564471+5.368296; // current y coordinate of the target low edge, hardcoded due to time constraints, find better way
 
-         Double_t ShiftX = TargetX/2.+0.0033519999999995775+2.;
-         Double_t ShiftY = -CurrentTargetY-20.188581+4+9.078588;
+         Double_t ShiftX = TargetX/2.+0.0033519999999995775-27;
+         Double_t ShiftY = -CurrentTargetY+35.890007+0.5384230000000017;
          Double_t ShiftZ = -200;
          ////////////////////////////////////////////
          auto localSND_physCS_comb = new TGeoCombiTrans("localSND_physCS",0.+ShiftX,0.+ShiftY, 0.+ShiftZ,localSND_physCS_rot);    // origin is 480m downstream of IP1, shifting the apparatus 4m upstream

--- a/shipLHC/SiSensor.h
+++ b/shipLHC/SiSensor.h
@@ -6,10 +6,12 @@
 
 namespace advsnd {
 
-const double sensor_width = 93.7 * ShipUnit::mm;
-const double sensor_length = 91.5 * ShipUnit::mm;
-const double module_length = 23.95 * ShipUnit::cm;
-const double module_width = 12.0 * ShipUnit::cm;
+const double sensor_length = 93.7 * ShipUnit::mm;
+const double sensor_width = 91.5 * ShipUnit::mm;
+const double sensor_thickness = 0.5 * ShipUnit::mm;
+const double module_width = 23.95 * ShipUnit::cm;
+const double module_length = 12.0 * ShipUnit::cm;
+const double support_thickness = 1.8 * ShipUnit::mm;
 const double sensor_gap = 3.1 * ShipUnit::mm;
 const int sensors = 2;
 const int strips = 768;
@@ -18,28 +20,38 @@ namespace target {
 const int rows = 4;
 const int columns = 2;
 const int planes = 2;
-const double module_row_gap = 0.5 * ShipUnit::mm;
-const double module_column_gap = 13.9 * ShipUnit::mm;
+const double module_dead_space_side_small = 6.45 * ShipUnit::mm;
+const double module_dead_space_side_large = 46.95 * ShipUnit::mm;
+const double module_dead_space_top = 13.15 * ShipUnit::mm;
+const double module_dead_space_bottom = module_dead_space_top;
+// cenral gap between columns/rows in a detective layer
+const double layer_central_gap = 13.4 * ShipUnit::mm;
+// column gap btw 2 modules, excluding dead spaces
+const double modules_column_gap = layer_central_gap - 2 * module_dead_space_side_small;
+// 2 rows of modules are staggred to form a module 'tandem'
+const double modules_rows_overlap = 27.6 * ShipUnit::mm;
+// two tandems of modules are staggered to form the central gap
+const double tandem_modules_rows_overlap = module_dead_space_top + module_dead_space_bottom - layer_central_gap;
+const double offset = module_dead_space_side_large - module_dead_space_top;
 }   // namespace target
 
 namespace hcal {
-const int rows = 6;
-const int columns = 3;
+const int rows = 4;
+const int columns = 2;
 const int planes = 2;
-const int stations = 5;
-const double module_row_gap = -26.3 * ShipUnit::mm + sensor_gap;
-const double module_column_gap = 2 * (sensor_length + sensor_gap) - module_length;
-const double plane_width = (2 * columns) * sensor_length + (2 * columns - 1) * sensor_gap + 2 * 6.45 * ShipUnit::mm;
+const int n_XY_layers = 28;
+const int n_X_layers = 6;
+const double module_dead_space_side_small = 6.45 * ShipUnit::mm;
+const double module_dead_space_side_large = 46.95 * ShipUnit::mm;
+const double module_dead_space_top = 13.15 * ShipUnit::mm;
+const double module_dead_space_bottom = module_dead_space_top;
+// cenral gap between columns in a detective layer
+const double layer_central_gap = 13.4 * ShipUnit::mm;
+// column gap btw 2 modules, excluding dead spaces
+const double modules_column_gap = layer_central_gap - 2 * module_dead_space_side_small;
+// rows of modules are staggred
+const double modules_rows_overlap = module_dead_space_top + module_dead_space_bottom + modules_column_gap;   // 26.8mm
 }   // namespace hcal
-
-namespace muon {
-const int rows = 6;
-const int columns = 3;
-const int planes = 1;
-const double module_row_gap = -26.3 * ShipUnit::mm + sensor_gap;
-const double module_column_gap = 2 * (sensor_length + sensor_gap) - module_length;
-const double plane_width = (2 * columns) * sensor_length + (2 * columns - 1) * sensor_gap + 2 * 6.45 * ShipUnit::mm;
-}   // namespace muon
 
 }   // namespace advsnd
 

--- a/shipLHC/run_simSND.py
+++ b/shipLHC/run_simSND.py
@@ -22,6 +22,7 @@ group = parser.add_mutually_exclusive_group()
 
 group.add_argument("--H6",   dest="testbeam",   help="use geometry of H8/H6 testbeam setup", action="store_true")
 group.add_argument("--AdvSND",   help="Use AdvSND setup", required=False, action="store_true")
+parser.add_argument("--stagger_hcal",help="Stagger HCAL for AdvSND setup",required=False,action="store_true")
 parser.add_argument("--Genie",   dest="genie",   help="Genie for reading and processing neutrino interactions (1 standard, 2 FLUKA, 3 Pythia, 4 GENIE geometry driver)", required=False, default = 0, type = int)
 parser.add_argument("--Ntuple",  dest="ntuple",  help="Use ntuple as input", required=False, action="store_true")
 parser.add_argument("--MuonBack",dest="muonback",  help="Generate events from muon background file, --Cosmics=0 for cosmic generator data", required=False, action="store_true")
@@ -108,7 +109,7 @@ shipRoot_conf.configure(0)     # load basic libraries, prepare atexit for python
 
 if options.testbeam:  snd_geo = ConfigRegistry.loadpy("$SNDSW_ROOT/geometry/sndLHC_H6geom_config.py")
 elif options.AdvSND:
-    snd_geo = ConfigRegistry.loadpy("$ADVSNDSW_ROOT/geometry/AdvSND_geom_config.py")
+    snd_geo = ConfigRegistry.loadpy("$ADVSNDSW_ROOT/geometry/AdvSND_geom_config.py",stagger_hcal=options.stagger_hcal)
 else:                         snd_geo = ConfigRegistry.loadpy("$SNDSW_ROOT/geometry/sndLHC_geom_config.py",
                                                                   nuTargetPassive = options.nuTargetPassive, useNagoyaEmulsions = options.useNagoyaEmulsions)
 

--- a/shipLHC/scripts/2dEventDisplay.py
+++ b/shipLHC/scripts/2dEventDisplay.py
@@ -36,7 +36,7 @@ parser.add_argument("-P", "--partition", dest="partition", help="partition of da
 parser.add_argument("--server", dest="server", help="xrootd server",default=os.environ["EOSSHIP"])
 parser.add_argument("-X", dest="extraInfo", help="print extra event info",default=True)
 
-parser.add_argument("-par", "--parFile", dest="parFile", help="parameter file", default=os.environ['SNDSW_ROOT']+"/python/TrackingParams.xml")
+parser.add_argument("-par", "--parFile", dest="parFile", help="parameter file", default=os.environ['ADVSNDSW_ROOT']+"/python/TrackingParams.xml")
 parser.add_argument("-hf", "--HoughSpaceFormat", dest="HspaceFormat", help="Hough space representation. Should match the 'Hough_space_format' name in parFile, use quotes", default='linearSlopeIntercept')
 
 options = parser.parse_args()

--- a/shipLHC/scripts/2dEventDisplay.py
+++ b/shipLHC/scripts/2dEventDisplay.py
@@ -108,7 +108,7 @@ for ht_task in HT_tasks.values():
     # force the output of reco task to genfit::Track
     # as the display code looks for such output
     ht_task.ForceGenfitTrackFormat()
-HT_tasks['muon_reco_task_Sf'].SetTrackingCase('passing_mu_AdvTarget')
+HT_tasks['muon_reco_task_Sf'].SetTrackingCase('nu_interaction_products')
 HT_tasks['muon_reco_task_nuInt'].SetTrackingCase('nu_interaction_products')
 
 run.Init()
@@ -262,19 +262,19 @@ def getAdvHitDensity(g, x_range=0.5):
 def loopEvents(start=0,save=False,withHoughTrack=-1,nTracks=0,option=None,Setup='',verbose=0,auto=False,hitColour=None):
  if 'simpleDisplay' not in h: ut.bookCanvas(h,key='simpleDisplay',title='simple event display',nx=1200,ny=1600,cx=1,cy=2)
  h['simpleDisplay'].cd(1)
- zStart = -300. # AdvSND MC
+ zStart = 100. # AdvSND MC
  if Setup == 'H6': zStart = 60.
  if Setup == 'TP': zStart = -50. # old coordinate system with origin in middle of target
  if 'xz' in h: 
     h.pop('xz').Delete()
     h.pop('yz').Delete()
  else:
-    h['xmin'],h['xmax'] = -100.,100. # AdvSND MC
-    h['ymin'],h['ymax'] = -100.,100. # AdvSND MC
-    h['zmin'],h['zmax'] = zStart,zStart+500.
+    h['xmin'],h['xmax'] = -80.,20. # AdvSND MC
+    h['ymin'],h['ymax'] = 0.,100. # AdvSND MC
+    h['zmin'],h['zmax'] = zStart,zStart+400.
     for d in ['xmin','xmax','ymin','ymax','zmin','zmax']: h['c'+d]=h[d]
- ut.bookHist(h,'xz','; z [cm]; x [cm]',500,h['czmin'],h['czmax'],200,h['cxmin'],h['cxmax'])
- ut.bookHist(h,'yz','; z [cm]; y [cm]',500,h['czmin'],h['czmax'],200,h['cymin'],h['cymax'])
+ ut.bookHist(h,'xz','; z [cm]; x [cm]',400,h['czmin'],h['czmax'],100,h['cxmin'],h['cxmax'])
+ ut.bookHist(h,'yz','; z [cm]; y [cm]',400,h['czmin'],h['czmax'],100,h['cymin'],h['cymax'])
 
  proj = {1:'xz',2:'yz'}
  h['xz'].SetStats(0)
@@ -633,30 +633,31 @@ def twoTrackEvent(sMin=10,dClMin=7,minDistance=1.5,sepDistance=0.5):
 
 def drawDetectors():
     """ Read the detector geometry and draw its elements on the display. """
-    nodes = {'volAdvTarget_1/volTargetWall_1':ROOT.kGray+1}
+    nodes = {'volAdvTarget_0/volWall_0/volPlate_1':ROOT.kGray+1}
     geoVer = checkGeoVersion()
     if geoVer!=2:
         print('This is an older version of the geometry and it is likely incompatible with this version of the drawDetectors function of the 2dED.')
     for i in range(geo.snd_geo.AdvTarget.nTT):
-        nodes['volAdvTarget_1/volTargetWall_{}'.format(i)]=ROOT.kGray+1
-        nodes['volAdvTarget_1/TrackingStation_{}'.format(i)]=ROOT.kBlue
+        nodes['volAdvTarget_0/volWall_{}/volPlate_1'.format(i)]=ROOT.kGray+1
+        nodes['volAdvTarget_0/Target_Layer_{}'.format(i)]=ROOT.kBlue
 
-    for i in range(geo.snd_geo.AdvMuFilter.Nplanes):
-        nodes['volAdvMuFilter_0/volFeWall_{}'.format(i)] = ROOT.kGreen -6
-        nodes['volAdvMuFilter_0/TrackingStation_{}'.format(i)] = ROOT.kRed -2
-        if i > geo.snd_geo.AdvMuFilter.Nplanes-2: continue
-        for j in range(geo.snd_geo.AdvMuFilter.Nplanes-2):
+    for i in range(ROOT.advsnd.hcal.n_XY_layers+ROOT.advsnd.hcal.n_X_layers):
+        nodes['volAdvMuFilter_0/volFeSlab{}'.format(i)] = ROOT.kGreen -6
+        nodes['volAdvMuFilter_0/volMagnetizedFe_{}'.format(i)] = ROOT.kGreen -6
+        nodes['volAdvMuFilter_0/HCAL_Layer_{}'.format(i)] = ROOT.kRed -2
+        #if i > ROOT.advsnd.hcal.n_XY_layers+ROOT.advsnd.hcal.n_X_layers-2: continue
+        for j in range(ROOT.advsnd.hcal.n_XY_layers+ROOT.advsnd.hcal.n_X_layers-2):
             if geoVer == 1:
                 nodes['volAdvMuFilter_0/volMuonSysDet_{}_{}/volBar_{}'.format(i, i, i*100+j)] = ROOT.kGray
             elif geoVer == 2:
                 nodes['volAdvMuFilter_0/volMuonSysDet_{}'.format(i)] = ROOT.kGray
     
     for i in range(2):
-        nodes['volAdvMuFilter_0/volVertCoil_{}'.format(i)] = ROOT.kOrange+1
-        nodes['volAdvMuFilter_0/volCoil_{}'.format(i)] = ROOT.kOrange+1
+        nodes['volAdvMuFilter_0/volFrontCoil_{}'.format(i)] = ROOT.kOrange+1
+        nodes['volAdvMuFilter_0/volLatCoil_{}'.format(i)] = ROOT.kOrange+1
     if geoVer != 2:
-        nodes['volAdvMuFilter_0/volMagTracker1_10000'] = ROOT.kGray   
-        nodes['volAdvMuFilter_0/volMagTracker2_10001'] = ROOT.kGray  
+        nodes['volAdvMuFilter_0/volMagTracker1_10000'] = ROOT.kGray
+        nodes['volAdvMuFilter_0/volMagTracker2_10001'] = ROOT.kGray
         nodes['volAdvMuFilter_0/volDownMagTracker_10002'] = ROOT.kGray
         nodes['volAdvMuFilter_0/volDownstreamMagnet_0/volDownVertCoil1_0'] = ROOT.kOrange+1
         nodes['volAdvMuFilter_0/volDownstreamMagnet_0/volDownVertCoil2_0'] = ROOT.kOrange+1
@@ -668,7 +669,7 @@ def drawDetectors():
     nodes['volAdvMuFilter_0/volMagTracker_10002'] = ROOT.kGray
 
     #passNodes = {'Wall','Coil', 'Block','Yoke'}
-    passNodes = {'Wall','Coil'}
+    passNodes = {'Plate','Coil'}
     proj = {'X':0, 'Y':1}
     for node_ in nodes:
         node = '/cave_1/Detector_0/'+node_
@@ -683,11 +684,10 @@ def drawDetectors():
                 if not nav.CheckPath(node): continue
                 nav.cd(node)
                 N = nav.GetCurrentNode()
-                # get rid of the Coil element for the vertical projection
-                # FIXME change the naming of the Coil and VertCoil in the geo file
+                # get rid of the LatCoil element for Y projection
                 if (N.GetVolume().GetName().find('Coil')>0
-                   and N.GetVolume().GetName().find('VertCoil')<0
-                   and p=='X'): continue                
+                   and N.GetVolume().GetName().find('LatCoil')>0):
+                     continue
                 S = N.GetVolume().GetShape()
                 scale = 1
                 if N.GetVolume().GetName().find('FeWall')>0:
@@ -695,13 +695,13 @@ def drawDetectors():
                 dx,dy,dz = S.GetDX()/scale,S.GetDY()/scale,S.GetDZ()
                 ox,oy,oz = S.GetOrigin()[0],S.GetOrigin()[1],S.GetOrigin()[2]
                 P = {}
-                M = {}                
-                if p=='X':
+                M = {}
+                if p=='X' and N.GetVolume().GetName().find('Layer')<0:
                     P['LeftBottom'] = array('d',[-dx+ox,oy,-dz+oz])
                     P['LeftTop'] = array('d',[dx+ox,oy,-dz+oz])
                     P['RightBottom'] = array('d',[-dx+ox,oy,dz+oz])
                     P['RightTop'] = array('d',[dx+ox,oy,dz+oz])
-                elif p=='Y':
+                elif p=='Y' or N.GetVolume().GetName().find('Layer')>0:
                     P['LeftBottom'] = array('d',[ox,-dy+oy,-dz+oz])
                     P['LeftTop'] = array('d',[ox,dy+oy,-dz+oz])
                     P['RightBottom'] = array('d',[ox,-dy+oy,dz+oz])
@@ -733,6 +733,15 @@ def drawDetectors():
                     X.SetPoint(4,M['LeftBottom'][2],M['LeftBottom'][c])
                 X.SetLineColor(nodes[node_])
                 X.SetLineWidth(1)
+                # Only show detector volumes if they measure the corresponding coordinate
+                if ( p=='Y' and node.find("Layer_")>0 and int(node[node.find("Layer_")+6:])%2 == 1 ) or \
+                   ( p=='X' and node.find("Layer_")>0 and int(node[node.find("Layer_")+6:])%2 == 0 ):
+                    X.SetLineWidth(0)
+                if  node.find("HCAL_Layer_")>0 and int(node[node.find("Layer_")+6:])>27:
+                  if p=='X':
+                     X.SetLineWidth(1)
+                  else:
+                     X.SetLineWidth(0)
                 h['simpleDisplay'].cd(c+1)
                 if any(passNode in node for passNode in passNodes):
                    X.SetFillColorAlpha(nodes[node_], 0.5)

--- a/sndFairTasks/DigiTaskSND.cxx
+++ b/sndFairTasks/DigiTaskSND.cxx
@@ -192,19 +192,16 @@ void DigiTaskSND::digitiseAdvTarget()
     for (auto* ptr : *AdvTargetPoints) {
         auto* point = dynamic_cast<AdvTargetPoint*>(ptr);
         auto detID = point->GetDetectorID();
-        int station = point->GetStation();
-        int plane = point->GetPlane();
+        int layer = point->GetLayer();
         int sensor_module = point->GetModule();
         int sensor = detID;
         auto path = TString::Format("/cave_1/"
                                     "Detector_0/"
-                                    "volAdvTarget_1/"
-                                    "TrackingStation_%d/"
-                                    "TrackerPlane_%d/"
+                                    "volAdvTarget_0/"
+                                    "Target_Layer_%d/"
                                     "SensorModule_%d/"
-                                    "SensorVolumeTarget_%d",
-                                    station,
-                                    plane,
+                                    "Target_SensorVolume_%d",
+                                    layer,
                                     sensor_module,
                                     sensor);
         // TODO loop by module?
@@ -222,7 +219,7 @@ void DigiTaskSND::digitiseAdvTarget()
         double local_pos[3];
         // Move to local coordinates (including rotation) to determine strip
         nav->MasterToLocal(global_pos, local_pos);
-        int strip = floor((local_pos[0] / (advsnd::sensor_width / advsnd::strips)) + (advsnd::strips / 2));
+        int strip = floor((local_pos[1] / (advsnd::sensor_length / advsnd::strips)) + (advsnd::strips / 2));
         strip = max(0, strip);
         strip = min(advsnd::strips - 1, strip);
 
@@ -262,19 +259,16 @@ void DigiTaskSND::digitiseAdvMuFilter()
     for (auto* ptr : *AdvMuFilterPoints) {
         auto* point = dynamic_cast<AdvMuFilterPoint*>(ptr);
         auto detID = point->GetDetectorID();
-        int station = point->GetStation();
-        int plane = point->GetPlane();
+        int layer = point->GetLayer();
         int sensor_module = point->GetModule();
         int sensor = detID;
         auto path = TString::Format("/cave_1/"
                                     "Detector_0/"
                                     "volAdvMuFilter_0/"
-                                    "TrackingStation_%d/"
-                                    "TrackerPlane_%d/"
+                                    "HCAL_Layer_%d/"
                                     "SensorModule_%d/"
-                                    "SensorVolumeFilter_%d",
-                                    station,
-                                    plane,
+                                    "HCAL_SensorVolume_%d",
+                                    layer,
                                     sensor_module,
                                     sensor);
         // TODO loop by module?
@@ -292,7 +286,7 @@ void DigiTaskSND::digitiseAdvMuFilter()
         double local_pos[3];
         // Move to local coordinates (including rotation) to determine strip
         nav->MasterToLocal(global_pos, local_pos);
-        int strip = floor((local_pos[0] / (advsnd::sensor_width / advsnd::strips)) + (advsnd::strips / 2));
+        int strip = floor((local_pos[1] / (advsnd::sensor_length / advsnd::strips)) + (advsnd::strips / 2));
         strip = max(0, strip);
         strip = min(advsnd::strips - 1, strip);
 


### PR DESCRIPTION
Update using the latest(as of last months of 2024) geometry model where modules overlap.
Based off on the NoExcOpt branch so the detector is laying on the TI18 floor as it is.
The layout of a modules is made more realistic - the support is reduced to a frame,
 which leaves larger air gaps between the tungsten and the Si sensor. The latter is
 very important for the development of high-E showers!
 Also, the concept of a station is replaced by a layer to unify language between sw 
 and the detector construction (schematics, papers, expert communication).
 
 All this was tested on particle gun MC verifying the Nstrips per sensor are  768, and the XYZ profile of an interaction
 is reproduced - meaning the GetPosition() methods are correct. 
 
 In addition, run_sim is equipped with an option to stagger the HCAL XY layers
 in an attempt to ease the study the effect of layer staggering on shower containment.