### PR TITLE
Geant4 update

### DIFF
--- a/gconfig/SetCuts.C
+++ b/gconfig/SetCuts.C
@@ -1,6 +1,8 @@
 
 /** Configuration macro for setting common cuts and processes for G3, G4 and Fluka (M. Al-Turany 27.03.2008)
     specific cuts and processes to g3 or g4 should be set in the g3Config.C, g4Config.C or flConfig.C
+    Comment out all cuts defined in this macro (S. Ilieva 3.03.2026)
+    essentially removing the 1 MeV particle production cut-off for SND@LHC G4 simulations
 
 */
 
@@ -33,20 +35,22 @@ void SetCuts()
   gMC->SetProcess("LOSS",1); /**energy loss*/
   gMC->SetProcess("MULS",1); /**multiple scattering*/
 
-  Double_t cut1 = 1.0E-3;         // GeV --> 1 MeV
-  Double_t cutb = 1.0E4;          // GeV --> 10 TeV
-  Double_t tofmax = 1.E10;        // seconds
-  cout << "SetCuts Macro: Setting cuts.." <<endl;
+  cout << "SetCuts Macro: No cuts to be set in here." <<endl;
+  
+  //Double_t cut1 = 1.0E-3;         // GeV --> 1 MeV
+  //Double_t cutb = 1.0E4;          // GeV --> 10 TeV
+  //Double_t tofmax = 1.E10;        // seconds
+  //cout << "SetCuts Macro: Setting cuts.." <<endl;
 
-  gMC->SetCut("CUTGAM",cut1);   /** gammas (GeV)*/
-  gMC->SetCut("CUTELE",cut1);   /** electrons (GeV)*/
-  gMC->SetCut("CUTNEU",cut1);   /** neutral hadrons (GeV)*/
-  gMC->SetCut("CUTHAD",cut1);   /** charged hadrons (GeV)*/
-  gMC->SetCut("CUTMUO",cut1);   /** muons (GeV)*/
-  gMC->SetCut("BCUTE",cut1);    /** electron bremsstrahlung (GeV)*/
-  gMC->SetCut("BCUTM",cut1);    /** muon and hadron bremsstrahlung(GeV)*/
-  gMC->SetCut("DCUTE",cut1);    /** delta-rays by electrons (GeV)*/
-  gMC->SetCut("DCUTM",cut1);    /** delta-rays by muons (GeV)*/
-  gMC->SetCut("PPCUTM",cut1);   /** direct pair production by muons (GeV)*/
-  gMC->SetCut("TOFMAX",tofmax); /**time of flight cut in seconds*/
+  //gMC->SetCut("CUTGAM",cut1);   /** gammas (GeV)*/
+  //gMC->SetCut("CUTELE",cut1);   /** electrons (GeV)*/
+  //gMC->SetCut("CUTNEU",cut1);   /** neutral hadrons (GeV)*/
+  //gMC->SetCut("CUTHAD",cut1);   /** charged hadrons (GeV)*/
+  //gMC->SetCut("CUTMUO",cut1);   /** muons (GeV)*/
+  //gMC->SetCut("BCUTE",cut1);    /** electron bremsstrahlung (GeV)*/
+  //gMC->SetCut("BCUTM",cut1);    /** muon and hadron bremsstrahlung(GeV)*/
+  //gMC->SetCut("DCUTE",cut1);    /** delta-rays by electrons (GeV)*/
+  //gMC->SetCut("DCUTM",cut1);    /** delta-rays by muons (GeV)*/
+  //gMC->SetCut("PPCUTM",cut1);   /** direct pair production by muons (GeV)*/
+  //gMC->SetCut("TOFMAX",tofmax); /**time of flight cut in seconds*/
 }

--- a/gconfig/g4Config.C
+++ b/gconfig/g4Config.C
@@ -25,7 +25,7 @@ void Config()
 /// When more than one options are selected, they should be separated with '+'
 /// character: eg. stepLimit+specialCuts.
    TG4RunConfiguration* runConfiguration 
-           = new TG4RunConfiguration("geomRoot", "QGSP_BERT_HP_PEN", "stepLimiter+specialCuts+specialControls");
+           = new TG4RunConfiguration("geomRoot", "FTFP_BERT_HP_EMZ", "stepLimiter+specialCuts+specialControls");
 
 /// Create the G4 VMC 
    TGeant4* geant4 = new TGeant4("TGeant4", "The Geant4 Monte Carlo", runConfiguration);

--- a/gconfig/g4config.in
+++ b/gconfig/g4config.in
@@ -7,6 +7,13 @@
 /mcPhysics/g4NeutronHPVerbose 0 #   - suppress the warnings about missing neutron data
 /mcPhysics/g4HadronicProcessStoreVerbose 0
 
+# Geant4 range cut for all geo regions and all supported particle types: e+,e-, gamma, proton
+/mcPhysics/rangeCuts 2 mm
+# range cut for all geo regions and selected particle e.g.
+#/mcPhysics/rangeCutForGamma 2 mm
+# print the Geant4 and VMC cuts per material
+#/mcRegions/print true
+
 # switch on other sources of di muon 
 /physics_lists/em/PositronToMuons true
 /physics_lists/em/GammaToMuons true

--- a/shipLHC/run_simSND.py
+++ b/shipLHC/run_simSND.py
@@ -34,6 +34,7 @@ parser.add_argument("--Eend",    dest="Eend",    help="end of energy range of pa
 parser.add_argument("--EVx",    dest="EVx",    help="particle gun xpos", required=False, default=0, type=float)
 parser.add_argument("--EVy",    dest="EVy",    help="particle gun ypos", required=False, default=0, type=float)
 parser.add_argument("--EVz",    dest="EVz",    help="particle gun zpos", required=False, default=0, type=float)
+parser.add_argument('--eMin_store', type=float, help="kinetic energy cut for !particle storage! in MeV", dest='emin_store', default=100.)
 parser.add_argument("--FollowMuon",dest="followMuon", help="Make muonshield active to follow muons", required=False, action="store_true")
 parser.add_argument("--FastMuon",  dest="fastMuon",  help="Only transport muons for a fast muon only background estimate", required=False, action="store_true")
 parser.add_argument('--eMin', type=float, help="energy cut", dest='ecut', default=-1.)
@@ -276,10 +277,10 @@ if MCTracksWithHitsOnly:
  fStack.SetEnergyCut(-100.*u.MeV)
 elif MCTracksWithEnergyCutOnly:
  fStack.SetMinPoints(-1)
- fStack.SetEnergyCut(100.*u.MeV)
+ fStack.SetEnergyCut(options.emin_store*u.MeV)
 elif MCTracksWithHitsOrEnergyCut: 
  fStack.SetMinPoints(1)
- fStack.SetEnergyCut(100.*u.MeV)
+ fStack.SetEnergyCut(options.emin_store*u.MeV)
 elif options.deepCopy: 
  fStack.SetMinPoints(0)
  fStack.SetEnergyCut(0.*u.MeV)


### PR DESCRIPTION
Important changes:

- change physics list to FTFP_BERT_HP_EMZ
- remove the 1MeV cut-off from the simulation
- start using production cut range at 2mm

Minor updates

- add flag to set the kin E for particle track storage through command line, default is 100MeV

This is practically cherry-picking a few commits from sndsw [PR 310](https://github.com/SND-LHC/sndsw/pull/310), related to GEANT4 MC.